### PR TITLE
Update feeds

### DIFF
--- a/data/feeds.json
+++ b/data/feeds.json
@@ -452,6 +452,18 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "WTI/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "XAG/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "XAU/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "XLM/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },

--- a/data/feeds.json
+++ b/data/feeds.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "AAPL/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "AAVE/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -9,6 +13,10 @@
   },
   {
     "name": "ALGO/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "AMZN/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -29,6 +37,10 @@
   },
   {
     "name": "ARB/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "ARKK/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -112,6 +124,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "COIN/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "COMP/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -192,11 +208,19 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "GME/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "GMX/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
     "name": "GNO/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "GOOGL/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -229,6 +253,10 @@
   },
   {
     "name": "JOE/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "JPM/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -280,6 +308,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "META/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "METIS/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -296,6 +328,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "MSFT/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "MXN/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -304,7 +340,15 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "NFLX/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "NGN/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "NVDA/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -392,6 +436,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "SPY/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "STETH/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -421,6 +469,14 @@
   },
   {
     "name": "TRY/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "TSLA/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "TSM/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {

--- a/data/feeds.json
+++ b/data/feeds.json
@@ -220,6 +220,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "GNS/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "GOOGL/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/nodaryio/utilities.git"
   },
-  "version": "0.7.0",
+  "version": "0.6.1",
   "private": false,
   "main": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/nodaryio/utilities.git"
   },
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": false,
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
Following feeds for `crypto`, `stock` and `commodity` were added:

```json
{
  "crypto": [
    "GNS/USD",
  ],

  "commodity": [
    "XAG/USD",
    "XAU/USD",
    "WTI/USD"
  ],

  "stock": [
    "AAPL/USD",
    "AMZN/USD",
    "ARKK/USD",
    "COIN/USD",
    "GME/USD",
    "GOOGL/USD",
    "JPM/USD",
    "META/USD",
    "MSFT/USD",
    "NFLX/USD",
    "NVDA/USD",
    "SPY/USD",
    "TSLA/USD",
    "TSM/USD"
  ]
}
```

P.S.: I have postponed creating tag for v0.7.0 until after the merge.