### PR TITLE
Update feeds

### DIFF
--- a/data/feeds.json
+++ b/data/feeds.json
@@ -60,6 +60,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "BABA/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "BAL/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -177,6 +181,10 @@
   },
   {
     "name": "ETH/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "ETHx/ETH Exchange Rate",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -332,6 +340,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "MATICx/MATIC Exchange Rate",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "META/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -376,6 +388,10 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "NG/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "NGN/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
@@ -409,6 +425,18 @@
   },
   {
     "name": "PHP/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "PYPL/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "PYTH/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "QQQ/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -488,11 +516,19 @@
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
+    "name": "stETH/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
     "name": "STETH/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
     "name": "STG/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "stMATIC/MATIC Exchange Rate",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {
@@ -557,6 +593,10 @@
   },
   {
     "name": "WBTC/USD",
+    "deviationThresholdsInPercentages": [0.25, 0.5, 1]
+  },
+  {
+    "name": "WOO/USD",
     "deviationThresholdsInPercentages": [0.25, 0.5, 1]
   },
   {


### PR DESCRIPTION
See related issues https://github.com/api3dao/tasks/issues/445 and https://github.com/api3dao/tasks/issues/479

Following pairs are added:

**Commodity:**

1. NG/USD

**Crypto:**

1. PYTH/USD
2. WOO/USD
3. stETH/USD (Added for the sake of name convention, still STETH/USD exists in fleet)

**LSD:**

1. ETHx/ETH Exchange Rate
2. MATICx/MATIC Exchange Rate
3. stMATIC/MATIC Exchange Rate

**Stock:**

1. BABA/USD
2. PYPL/USD
3. QQQ/USD

